### PR TITLE
Staging/Dev API through hostname

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,9 @@
 const hostname = window && window.location && window.location.hostname;
 
+// Replace 'false' with 'true' when testing backend API locally.
+const isLocal = false && window && window.location && 
+                (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1")
+
 let backendHost;
 if (hostname === 'www.streamcamel.com') {
     backendHost = 'https://api.streamcamel.com';
@@ -7,14 +11,13 @@ if (hostname === 'www.streamcamel.com') {
     backendHost = 'https://api.staging.streamcamel.com';
 } else if (hostname === 'www.dev.streamcamel.com') {
     backendHost = 'https://api.dev.streamcamel.com';
+} else if (isLocal) {
+    backendHost = 'http://localhost:8800';
 } else {
-    // TODO: Make this works with localhost
     backendHost = 'https://api.streamcamel.com';
 }
 
 export function backendURL(path) {
-
-
     return backendHost + path;
 }
 


### PR DESCRIPTION
Use a different backend API depending on the environment being deployed to.
Idea from: https://daveceddia.com/multiple-environments-with-react/

Unfortunately I don't know of any easy way to test this without deploying.