### PR TITLE
Reduce streamers time range to 2 days and limit to 48 entries

### DIFF
--- a/src/components/TopStreamersPage.js
+++ b/src/components/TopStreamersPage.js
@@ -22,7 +22,7 @@ const TopGamesPage = () => {
 
         if(prevPath !== location.pathname)
         {
-            let url = appConfig.backendURL('/users_stats?limit=100&period=1w');
+            let url = appConfig.backendURL('/users_stats?limit=48&period=2d');
             fetch(url)
                 .then(res => res.json())
                 .then(res => setData(res))


### PR DESCRIPTION
This is the easiest change to make the top streamers page fast from 10+s to ~1.3s